### PR TITLE
Fix enemy tracking and memory handling

### DIFF
--- a/CppBeginnersFinalPeer&Thai/Enemy.cpp
+++ b/CppBeginnersFinalPeer&Thai/Enemy.cpp
@@ -2,6 +2,7 @@
 #include "Enemy.h"
 #include <string>
 #include <windows.h>
+#include <cstdlib>
 
 #define REACTION_RANGE 2
 #define BATTLE_RANGE 1
@@ -13,15 +14,13 @@ Enemy::Enemy(int maxHp, int normalDmg, int elementalDmg, Elements element, const
     speed = 1;
 }
 
-void Enemy::AddPatrolPoint(Map map, Vector2 point)
+void Enemy::AddPatrolPoint(const Map& map, Vector2 point)
 {
     if (IsPointValid(map, point))
         patrolRoute.push_back(point);
-    else
-        int x;
 }
 
-void Enemy::Patrol(Map map)
+void Enemy::Patrol(Map& map)
 {
     GoToPoint(map, patrolRoute.at(currentPoint));
 
@@ -33,7 +32,7 @@ void Enemy::Patrol(Map map)
     }
 }
 
-void Enemy::GoToPoint(Map map, Vector2 point)
+void Enemy::GoToPoint(Map& map, Vector2 point)
 {
     Vector2 nextPos;
 
@@ -92,7 +91,7 @@ void Enemy::GoToPoint(Map map, Vector2 point)
     return;
 }
 
-bool Enemy::IsPointValid(Map map, Vector2 point)
+bool Enemy::IsPointValid(const Map& map, const Vector2& point)
 {
     if (map.CheckIsPointInMap(point))
         if (map.GetCharAt(point) == Symbols::CLEAR)
@@ -100,7 +99,7 @@ bool Enemy::IsPointValid(Map map, Vector2 point)
     return false;
 }
 
-void Enemy::ChangePosition(Map map, Vector2 nextPos)
+void Enemy::ChangePosition(Map& map, const Vector2& nextPos)
 {
     map.UpdatePosition(nextPos, Symbols::ENEMY,
         map.GetCharAt(nextPos) == Symbols::ENEMY); //move enemy char to new position
@@ -112,7 +111,7 @@ void Enemy::ChangePosition(Map map, Vector2 nextPos)
     return;
 }
 
-void Enemy::Update(Map map, Player player)
+void Enemy::Update(Map& map, const Player& player)
 {
     if (IsInRange(player.GetPlayerPos(), REACTION_RANGE))
     {
@@ -138,8 +137,8 @@ bool Enemy::IsInRange(Vector2 targetPosition, int range)
     }
     */
 
-    if ((position.x - targetPosition.x <= range || targetPosition.x - position.x <= range)
-        && position.y - targetPosition.y <= range || targetPosition.y - position.y <= range)
-        return true;
-    return false;
+    int dx = abs(position.x - targetPosition.x);
+    int dy = abs(position.y - targetPosition.y);
+
+    return dx <= range && dy <= range;
 }

--- a/CppBeginnersFinalPeer&Thai/Enemy.h
+++ b/CppBeginnersFinalPeer&Thai/Enemy.h
@@ -18,14 +18,14 @@ private:
 	int speed;
 	int currentPoint;
 	std::vector<Vector2> patrolRoute;
-	void GoToPoint(Map map, Vector2 point);
-	bool IsPointValid(Map map, Vector2 point);
-	void ChangePosition(Map map, Vector2 nextPos);
-	bool IsInRange(Vector2 playerLocation, int range);
+        void GoToPoint(Map& map, Vector2 point);
+        bool IsPointValid(const Map& map, const Vector2& point);
+        void ChangePosition(Map& map, const Vector2& nextPos);
+        bool IsInRange(Vector2 playerLocation, int range);
 public:
 	Enemy(int maxHp, int normalDmg, int elementalDmg, Elements element, const Vector2& location);
-	void AddPatrolPoint(Map map, Vector2 point);
-	void Patrol(Map map);
-	void Update(Map map, Player player);
+        void AddPatrolPoint(const Map& map, Vector2 point);
+        void Patrol(Map& map);
+        void Update(Map& map, const Player& player);
 };
 #endif 

--- a/CppBeginnersFinalPeer&Thai/Game.cpp
+++ b/CppBeginnersFinalPeer&Thai/Game.cpp
@@ -33,7 +33,7 @@ void Game::RunGameLoop()
 		lastTime = now;
 		accumulator += delta;
 
-		player->Update(currentLevel->GetMap(), *player);
+                player->Update(currentLevel->GetMap());
 
 		//currentLevel->UpdateEnemies();
 
@@ -82,7 +82,7 @@ while (running)
 	auto startTime = high_resolution_clock::now();
 
 	// === Update Player ===
-	player->Update(currentLevel->GetMap(), *player);
+    player->Update(currentLevel->GetMap());
 
 	// === Update Enemies ===
 	currentLevel->Update();

--- a/CppBeginnersFinalPeer&Thai/Level.cpp
+++ b/CppBeginnersFinalPeer&Thai/Level.cpp
@@ -57,14 +57,23 @@ Level::Level(Levels mapLevel, Player& player) : levelNum(mapLevel), player(playe
 
 		}
 	}
-	Enemy temp = Enemy(10, 5, 5, Elements::FIRE, Vector2(5, 10));
-	temp.AddPatrolPoint(*map, Vector2(2, 11));
-	temp.AddPatrolPoint(*map, Vector2(7, 11));
-	enemies.push_back(&temp);
+        Enemy* temp = new Enemy(10, 5, 5, Elements::FIRE, Vector2(5, 10));
+        temp->AddPatrolPoint(*map, Vector2(2, 11));
+        temp->AddPatrolPoint(*map, Vector2(7, 11));
+        enemies.push_back(temp);
 	//Debug print
 	//map->UpdatePosition(Vector2(2, 11), 'G', Ui::GetColorForChar('G'));
 	//map->UpdatePosition(Vector2(7, 11), '8', Ui::GetColorForChar('G'));
     Ui::PrintFrame(*this, levelNum, player);
+}
+
+Level::~Level()
+{
+    for (auto* e : enemies)
+    {
+        delete e;
+    }
+    delete map;
 }
 
 void Level::LoadMapFile()

--- a/CppBeginnersFinalPeer&Thai/Level.h
+++ b/CppBeginnersFinalPeer&Thai/Level.h
@@ -28,7 +28,8 @@ private:
 
 public:
 
-	Level(Levels mapLevel, Player& p);
+        Level(Levels mapLevel, Player& p);
+        ~Level();
 
 	void Update();
 

--- a/CppBeginnersFinalPeer&Thai/Map.cpp
+++ b/CppBeginnersFinalPeer&Thai/Map.cpp
@@ -50,10 +50,11 @@ bool Map::IsTileClear(const Vector2& tile) const
 	return CheckIsPointInMap(tile) && mapMat[tile.x][tile.y] == Symbols::CLEAR;
 }
 
-Symbols Map::GetCharAt(Vector2& pos)
+Symbols Map::GetCharAt(const Vector2& pos) const
 {
-	if (CheckIsPointInMap(pos))
-		return static_cast<Symbols>(mapMat[pos.x][pos.y]);
+        if (CheckIsPointInMap(pos))
+                return static_cast<Symbols>(mapMat[pos.x][pos.y]);
+        return Symbols::CLEAR;
 }
 
 bool Map::CheckIsPointInMap(const Vector2& point) const

--- a/CppBeginnersFinalPeer&Thai/Map.h
+++ b/CppBeginnersFinalPeer&Thai/Map.h
@@ -36,7 +36,7 @@ public:
 
 	bool IsTileClear(const Vector2& tile) const;
 
-	Symbols GetCharAt(Vector2& pos);
+        Symbols GetCharAt(const Vector2& pos) const;
 
 	bool CheckIsPointInMap(const Vector2& point) const;
 };

--- a/CppBeginnersFinalPeer&Thai/Player.cpp
+++ b/CppBeginnersFinalPeer&Thai/Player.cpp
@@ -8,10 +8,10 @@ Player::Player(const Vector2& pos) : GameObject(position)
 {
 	position = pos;
 	keyAcquired = false;
-	Inventory* inventory = new Inventory();
+        // inventory managed as a member; no need for dynamic allocation
 }
 
-void Player::Move(Map map, Vector2& direction)
+void Player::Move(Map& map, Vector2& direction)
 {
 	bool isDirectionValid = false;
 	Vector2 tempPos = position + direction;
@@ -42,7 +42,7 @@ void Player::Move(Map map, Vector2& direction)
 
 }
 
-void Player:: Update(Map map, Player player)
+void Player::Update(Map& map)
 {
 	Vector2 direction = Vector2 (0,0);
 	char playerInput;

--- a/CppBeginnersFinalPeer&Thai/Player.h
+++ b/CppBeginnersFinalPeer&Thai/Player.h
@@ -20,8 +20,8 @@ private:
 public:
 	bool keyAcquired;
 	Player(const Vector2& location);
-	void Move(Map map, Vector2& direction);
-	void Update(Map map, Player player);
+        void Move(Map& map, Vector2& direction);
+        void Update(Map& map);
 	bool IsKeyAcquired();
 	void NewLevel();
 	Vector2 GetPlayerPos();


### PR DESCRIPTION
## Summary
- fix `Enemy` patrol and chase by passing map/player by reference
- correct range check logic in `Enemy::IsInRange`
- update player functions to use map reference and remove unused player parameter
- allocate enemies dynamically and clean them up in `Level` destructor
- expose constant `Map::GetCharAt` and adjust callers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68829a12f6688322badef61853dfe3e2